### PR TITLE
Introducing network/virtual service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*.test

--- a/lib/svc/manifest/network/network-virtual.xml
+++ b/lib/svc/manifest/network/network-virtual.xml
@@ -80,6 +80,7 @@
 
 	<property_group name='startd' type='framework'>
 		<propval name='duration' type='astring' value='transient' />
+		<propval name='critical_failure_count' type='integer' value='1'/>
 	</property_group>
 
 	<template>

--- a/lib/svc/manifest/network/network-virtual.xml
+++ b/lib/svc/manifest/network/network-virtual.xml
@@ -56,7 +56,7 @@
 	<exec_method
 		type='method'
 		name='start'
-		exec='/lib/svc/method/net-virtual'
+		exec='/lib/svc/method/net-virtual start'
 		timeout_seconds='300' />
 
 	<exec_method
@@ -64,6 +64,12 @@
 		name='stop'
 		exec=':true'
 		timeout_seconds='3' />
+
+	<exec_method
+		type='method'
+		name='refresh'
+		exec='/lib/svc/method/net-virtual refresh'
+		timeout_seconds='300' />
 
 	<property_group name='startd' type='framework'>
 		<propval name='duration' type='astring' value='transient' />

--- a/lib/svc/manifest/network/network-virtual.xml
+++ b/lib/svc/manifest/network/network-virtual.xml
@@ -51,6 +51,13 @@
 		<service_fmri value='svc:/network/varpd' />
 	</dependency>
 
+	<dependent
+		name='milestone-network'
+		grouping='optional_all'
+		restart_on='restart'>
+		<service_fmri value='svc:/milestone/network' />
+	</dependent>
+
 	<instance name='default' enabled='true'>
 
 	<exec_method

--- a/lib/svc/manifest/network/network-virtual.xml
+++ b/lib/svc/manifest/network/network-virtual.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ Copyright 2017 Erigones, s. r. o.  All rights reserved.
+ Use is subject to license terms.
+
+ CDDL HEADER START
+
+ The contents of this file are subject to the terms of the
+ Common Development and Distribution License (the "License").
+ You may not use this file except in compliance with the License.
+
+ You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ or http://www.opensolaris.org/os/licensing.
+ See the License for the specific language governing permissions
+ and limitations under the License.
+
+ When distributing Covered Code, include this CDDL HEADER in each
+ file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ If applicable, add the following below this CDDL HEADER, with the
+ fields enclosed by brackets "[]" replaced with your own identifying
+ information: Portions Copyright [yyyy] [name of copyright owner]
+
+ CDDL HEADER END
+
+	NOTE:  This service manifest is not editable; its contents will
+	be overwritten by package or patch operations, including
+	operating system upgrade.  Make customizations in a different
+	file.
+-->
+
+<service_bundle type='manifest' name='SUNWcsr:network-virtual'>
+
+<service
+	name='network/virtual'
+	type='service'
+	version='1'>
+
+	<dependency name="network-physical"
+		grouping="require_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/network/physical:default" />
+	</dependency>
+
+	<dependency
+		name='varpd'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/network/varpd' />
+	</dependency>
+
+	<instance name='default' enabled='true'>
+
+	<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/net-virtual'
+		timeout_seconds='300' />
+
+	<exec_method
+		type='method'
+		name='stop'
+		exec=':true'
+		timeout_seconds='3' />
+
+	<property_group name='startd' type='framework'>
+		<propval name='duration' type='astring' value='transient' />
+	</property_group>
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+				virtual network interfaces
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title='ifconfig' section='1M'
+				manpath='/usr/share/man' />
+		</documentation>
+	</template>
+
+	</instance>
+
+	<stability value='Unstable' />
+
+</service>
+
+</service_bundle>

--- a/lib/svc/method/net-physical
+++ b/lib/svc/method/net-physical
@@ -502,9 +502,18 @@ if smf_is_globalzone; then
     fi
 
     # Set up etherstubs
-    for stub in $(echo "${CONFIG_etherstub}" | sed -e "s/,/ /g"); do
-        /usr/sbin/dladm create-etherstub -t $stub || echo "ERROR: could not create etherstub ${stub}."
-    done
+    if [[ -n "${CONFIG_etherstub}" ]]; then
+        typeset -a Etherstubs=(${CONFIG_etherstub//,/ })
+
+        for stub in "${Etherstubs[@]}"; do
+            # Must fail on error (etherstubs are part of SYSINFO_Nic_Tags)
+            /usr/sbin/dladm create-etherstub -t $stub
+        done
+
+        # Reload sysinfo (etherstubs are part of SYSINFO_Nic_Tags)
+        /usr/bin/sysinfo -u
+        load_sdc_sysinfo
+    fi
 
     # Change MAC addresses
     if [[ -n "${CONFIG_change_mac}" ]]; then
@@ -532,22 +541,6 @@ if smf_is_globalzone; then
 
     # Make any mtu adjustments that may be necessary
     setup_mtu
-
-    # Create overlay_rules.json
-    config_overlays="$(set | grep "^CONFIG_overlay_[a-zA-Z0-9_]*[a-zA-Z_]=" | cut -d "_" -f 3- | cut -d "=" -f 1)"
-
-    if [[ -n "${config_overlays}" ]]; then
-        # The overlay configuration folder is placed on swap (does not exist after boot)
-        mkdir -p "$(dirname "${OVERLAY_RULES}")"
-        overlay_rules="{"
-
-        for overlay_name in ${config_overlays}; do
-            eval "overlay_rule=\${CONFIG_overlay_${overlay_name}}"
-            overlay_rules="${overlay_rules}\n    \"${overlay_name}\": \"${overlay_rule}\","
-        done
-
-        echo "$(echo "${overlay_rules}" | sed '$s/,$//')\n}" > "${OVERLAY_RULES}"
-    fi
 
     # Setup admin NIC
 
@@ -721,92 +714,6 @@ if smf_is_globalzone; then
     fi
 
     set_default_route
-
-    # Setup extra nics, if specified in the config file
-    nic_tags="${SYSINFO_Nic_Tags}"
-    if [[ -n "${nic_tags}" ]]; then
-        tags=(${nic_tags//,/ })
-
-        if boot_file_config_enabled; then
-            bootparam_ip_keys=""
-            bootparam_ip6_keys=""
-            config_ip_keys=${CONFIG_bootfile_ip_keys//,/ }
-            config_ip6_keys=${CONFIG_bootfile_ip6_keys//,/ }
-        else
-            bootparam_ip_keys=$(sdc_bootparams_keys | grep -- "-ip$" || true)
-            bootparam_ip6_keys=$(sdc_bootparams_keys | grep -- "-ip6$" || true)
-            config_ip_keys=$(sdc_config_keys | grep "_ip$" || true)
-            config_ip6_keys=$(sdc_config_keys | grep "_ip6$" || true)
-        fi
-
-        for tag in "${tags[@]}"; do
-
-            eval "link=\${SYSINFO_NIC_${tag}}"
-            if [[ -z "${link}" ]]; then
-                echo "WARNING: No link found with tag '${tag}'"
-                continue
-            fi
-
-            for key in ${config_ip_keys}; do
-                if [[ ${key} == ${tag}[0-9]_ip ]] || [[ ${key} == ${tag}[0-9][0-9]_ip ]]; then
-                    iface=${key//_ip/}
-                    #echo "   iface=$iface"
-                    eval "ip=\${CONFIG_${iface}_ip}"
-                    eval "netmask=\${CONFIG_${iface}_netmask}"
-                    eval "vlan=\${CONFIG_${iface}_vlan_id}"
-                    eval "macaddr=\${CONFIG_${iface}_mac}"
-                    eval "mtu=\${CONFIG_${iface}_mtu}"
-
-                    echo vnic_up "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up "${link}" "${iface}" "${ip}" "${netmask}" \
-                        "${vlan}" "${macaddr}" "" "${mtu}"
-                fi
-            done
-
-            for key in ${bootparam_ip_keys}; do
-                if [[ ${key} == ${tag}[0-9]-ip ]] || [[ ${key} == ${tag}[0-9][0-9]-ip ]]; then
-                    iface=${key//-ip/}
-                    eval "ip=\${BOOT_${iface}_ip}"
-                    eval "netmask=\${BOOT_${iface}_netmask}"
-                    eval "vlan=\${BOOT_${iface}_vlan_id}"
-                    eval "macaddr=\${BOOT_${iface}_mac}"
-                    eval "mtu=\${BOOT_${iface}_mtu}"
-                    echo vnic_up "${link}" "${iface}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up "${link}" "${iface}" "${ip}" "${netmask}" \
-                        "${vlan}" "${macaddr}" "" "${mtu}"
-                fi
-            done
-
-            for key in ${config_ip6_keys}; do
-                if [[ ${key} == ${tag}[0-9]_ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]_ip6 ]]; then
-                    iface=${key//_ip6/}
-                    #echo "   iface=$iface"
-                    eval "ip=\${CONFIG_${iface}_ip6}"
-                    eval "vlan=\${CONFIG_${iface}_vlan_id}"
-                    eval "macaddr=\${CONFIG_${iface}_mac}"
-                    eval "mtu=\${CONFIG_${iface}_mtu}"
-
-                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up6 "${link}" "${iface}" "${ip}" \
-                        "${vlan}" "${macaddr}" "${mtu}"
-                fi
-            done
-
-            for key in ${bootparam_ip6_keys}; do
-                if [[ ${key} == ${tag}[0-9]-ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]-ip6 ]]; then
-                    iface=${key//-ip6/}
-                    eval "ip=\${BOOT_${iface}_ip6}"
-                    eval "vlan=\${BOOT_${iface}_vlan_id}"
-                    eval "macaddr=\${BOOT_${iface}_mac}"
-                    eval "mtu=\${BOOT_${iface}_mtu}"
-                    echo vnic_up6 "${link}" "${iface}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
-                    vnic_up6 "${link}" "${iface}" "${ip}" \
-                        "${vlan}" "${macaddr}" "${mtu}"
-                fi
-            done
-
-        done
-    fi
 else
     # Non-global zones
 

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -257,7 +257,7 @@ function setup_vnic
         link="${overlay_rule_name}${vxlan_id}"
 
         if [[ ! "${vxlan_id}" =~ ^[0-9]+$ ]]; then
-            echo "ERROR: Invalid overlay VXLAN for VNIC: ${iface}"
+            echo "ERROR: Invalid overlay VXLAN ID \"${vxlan_id}\" for VNIC: ${iface}"
             return 1
         fi
 
@@ -358,8 +358,8 @@ function create_overlay_rules
 #
 function create_vnics
 {
+    set -o errexit
     set -o xtrace
-    # set -o errexit
 
     nic_tags="${SYSINFO_Nic_Tags}"
 
@@ -407,7 +407,7 @@ function create_vnics
             if [[ ${key} == ${tag}[0-9]-ip ]] || [[ ${key} == ${tag}[0-9][0-9]-ip ]]; then
                 iface=${key//-ip/}
                 setup_vnic "${tag}" "${iface}" "BOOT" "4"
-                fi
+            fi
         done
 
         for key in ${config_ip6_keys}; do
@@ -428,6 +428,8 @@ function create_vnics
 
 function start
 {
+    set -o errexit
+
     log_if_state before
     create_overlay_rules
     create_vnics
@@ -439,6 +441,8 @@ function start
 
 function stop
 {
+    set -o errexit
+
     echo "ERROR: Not implemented" >&2
 
     return "${SMF_EXIT_OK}"
@@ -446,6 +450,8 @@ function stop
 
 function refresh
 {
+    set -o errexit
+
     echo "NOTE: Changing or removing existing VNICs is currently not supported." >&2
     echo "NOTE: Only adding of new VNICs will work." >&2
 

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -404,7 +404,7 @@ function create_overlay_rules
     config_overlay_rules="$(sdc_config_keys | grep "^overlay_rule_[a-zA-Z0-9_]*[a-zA-Z_]$" | cut -d "_" -f 3-)"
 
     if [[ -n "${config_overlay_rules}" ]]; then
-        # The overlay configuration folder is placed on swap (does not exist after boot)
+        # The overlay configuration folder is placed on ramdisk (does not exist after boot)
         mkdir -p "$(dirname "${OVERLAY_RULES}")"
         overlay_rules="{"
 

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -26,6 +26,83 @@
 # Copyright 2017 Erigones, s. r. o.
 #
 
+#
+# This script is responsible for creating VNICs (dladm create-vnic) based on
+# configuration in /usbkey/config or provided via boot parameters. It can also
+# create (replace) the overlay_rules.json file. Overlays are created only
+# if a VNIC is configured to be over an overlay. Etherstubs are created in
+# network/physical.
+#
+# It also supports creating of new VNICs added to /usbkey/config on a running
+# system via the `refresh` parameter. However, the refresh functionality is
+# currently limited to configuration of VNICs that do not exist in the OS yet.
+#
+
+#### EXAMPLE /usbkey/config entries:
+##
+#### Create etherstubs (performed in network/physical)
+#### (comma-separated list)
+##
+## etherstub=foo0,bar1,test30
+##
+##
+#### Create /var/run/smartdc/networking/overlay_rules.json
+##
+## overlay_rule_spam="-e vxlan -p vxlan/listen_ip=0.0.0.0,vxlan/listen_port=5000 \
+##    -s direct -p direct/dest_ip=10.20.30.40 -p direct/dest_port=4444 -p mtu=1400"
+## overlay_rule_ham_eggs="-e vxlan -p vxlan/listen_ip=0.0.0.0,vxlan/listen_port=4795 \
+##    -s files -p files/config=/var/db/ham_eggs.json -p mtu=1400"
+##
+##
+#### VNICs over normal physical interfaces or aggregation
+#### nic_tag=foobar
+##
+## foobar_nic=11:22:33:aa:bb:cc
+#### Or foobar_nic=aggr0 for VNIC/nic_tag over aggregation inteface named `aggr0`
+## foobar0_ip=192.168.11.22
+## foobar0_netmask=255.255.255.0
+## foobar0_vlan_id=...
+## foobar0_mac=...
+## foobar0_mtu=...
+##
+##
+#### VNICs on etherstubs
+#### The etherstub name must be listed in the `etherstub=` setting (see above)
+#### nic_tag=<etherstub-name>
+##
+## test30_0_ip=172.16.33.44
+## test30_0_netmask=255.255.240.0
+## test30_0_vlan_id=...
+## test30_0_mac=...
+## test30_0_mtu=...
+##
+##
+#### VNICs on overlays
+#### There must be an `overlay_rule=` setting for the overlay rule (see above)
+#### nic_tag=<overlay rule name>
+##
+## ham_eggs_0_vxlan_id=1234
+## ham_eggs_0_ip=10.55.66.77
+## ham_eggs_0_netmask=255.255.0.0
+## ham_eggs_0_vlan_id=...
+## ham_eggs_0_mac=...
+## ham_eggs_0_mtu=...
+
+#######################################
+# The /usbkey/config entries are based on the following pattern:
+#
+# <nic_tag>_<integer:vnic-suffix>_ip=
+# <nic_tag>_<integer:vnic-suffix>_netmask=
+# ... and so on ...
+#
+# + VNICs on normal and aggregation interfaces require <nic_tag>_nic=
+# + VNICs on overlays require <nic_tag>_<integer:vnic-suffix>_vxlan_id=
+#
+# NOTE: The <nic_tag>_<integer:vnic-suffix> format is preferred.
+#       (note the underscore)
+#
+#######################################
+
 . /lib/svc/share/smf_include.sh
 . /lib/sdc/config.sh
 . /lib/sdc/network.sh
@@ -42,7 +119,6 @@ LD_LIBRARY_PATH=/lib; export LD_LIBRARY_PATH
 # Hard-coded in nictagadm and in other places
 OVERLAY_RULES="/var/run/smartdc/networking/overlay_rules.json"
 
-typeset -a Etherstubs
 typeset MODE
 
 
@@ -53,15 +129,6 @@ function log_if_state
         echo "WARNING: 'ifconfig -a' failed"
     fi
     echo "== debug end: $1 =="
-}
-
-function load_etherstubs
-{
-    if [[ -n "${CONFIG_etherstub}" ]]; then
-        Etherstubs=(${CONFIG_etherstub//,/ })
-    else
-        Etherstubs=()
-    fi
 }
 
 function valid_mtu
@@ -219,19 +286,6 @@ function vnic_up6
     eval "vnic_${iface}_up=true"
 }
 
-function is_etherstub
-{
-    typeset value="$1"
-
-    for stub in "${Etherstubs[@]}"; do
-        if [[ "${stub}" == "${value}" ]]; then
-            return 0
-        fi
-    done
-
-    return 1
-}
-
 # Retrieve all necessary information about a vnic,
 # make sure its link exists,
 # call vnic_up.
@@ -254,10 +308,16 @@ function setup_vnic
     if [[ -n "${vxlan_id}" ]]; then
         # We have a vnic on overlay
         overlay_rule_name="${tag}"
-        link="${overlay_rule_name}${vxlan_id}"
 
         if [[ ! "${vxlan_id}" =~ ^[0-9]+$ ]]; then
             echo "ERROR: Invalid overlay VXLAN ID \"${vxlan_id}\" for VNIC: ${iface}"
+            return 1
+        fi
+
+        link="${overlay_rule_name}${vxlan_id}"
+
+        if [[ "${link}" == "${vnic_name}" ]]; then
+            echo "ERROR: Overlay name is the same as VNIC name: ${link}"
             return 1
         fi
 
@@ -279,11 +339,11 @@ function setup_vnic
         else
             echo "NOTE: Overlay \"${link}\" already exists for VNIC: ${iface}"
         fi
-    elif is_etherstub "${tag}"; then
-        # We have a vnic on etherstub
+    elif [[ "${tag}" =~ [0-9]$ ]]; then
+        # We have a vnic on etherstub (tag ends with a number)
         link="${tag}"
 
-        if [[ "${iface}" == "${link}"* ]]; then
+        if [[ "${iface}" =~ ^${link}[0-9]+$ ]]; then
             # Normalize interface name (bar010 -> bar10, foo03 -> foo3)
             vnic_prefix="$(echo "${link}" | sed 's/\([a-zA-Z_\.-]\)0$/\1/')"
             vnic_name="${vnic_prefix}${iface:${#link}}"
@@ -298,6 +358,7 @@ function setup_vnic
         fi
     fi
 
+    # This is the only difference between start and refresh
     if [[ "${MODE}" == "refresh" ]] && dladm show-vnic "${vnic_name}" > /dev/null 2>&1; then
         echo "WARNING: VNIC \"${vnic_name}\" already exists"
         return 0
@@ -397,29 +458,29 @@ function create_vnics
 
     for tag in "${tags_first[@]}" "${tags_last[@]}"; do
         for key in ${config_ip_keys}; do
-            if [[ ${key} == ${tag}[0-9]_ip ]] || [[ ${key} == ${tag}[0-9][0-9]_ip ]]; then
-                iface=${key//_ip/}
+            if [[ "${key}" =~ ^${tag}_?[0-9]+_ip$ ]]; then
+                iface="${key//_ip/}"
                 setup_vnic "${tag}" "${iface}" "CONFIG" "4"
             fi
         done
 
         for key in ${bootparam_ip_keys}; do
-            if [[ ${key} == ${tag}[0-9]-ip ]] || [[ ${key} == ${tag}[0-9][0-9]-ip ]]; then
-                iface=${key//-ip/}
+            if [[ "${key}" =~ ^${tag}_?[0-9]+-ip$ ]]; then
+                iface="${key//-ip/}"
                 setup_vnic "${tag}" "${iface}" "BOOT" "4"
             fi
         done
 
         for key in ${config_ip6_keys}; do
-            if [[ ${key} == ${tag}[0-9]_ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]_ip6 ]]; then
-                iface=${key//_ip6/}
+            if [[ "${key}" =~ ^${tag}_?[0-9]+_ip6$ ]]; then
+                iface="${key//_ip6/}"
                 setup_vnic "${tag}" "${iface}" "CONFIG" "6"
             fi
         done
 
         for key in ${bootparam_ip6_keys}; do
-            if [[ ${key} == ${tag}[0-9]-ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]-ip6 ]]; then
-                iface=${key//-ip6/}
+            if [[ "${key}" =~ ^${tag}_?[0-9]+-ip6$ ]]; then
+                iface="${key//-ip6/}"
                 setup_vnic "${tag}" "${iface}" "BOOT" "6"
             fi
         done
@@ -485,8 +546,6 @@ else
     load_sdc_bootparams
 fi
 
-load_etherstubs
-
 ####
 # Run
 ####
@@ -495,12 +554,10 @@ case "${1}" in
     start|stop|refresh)
         MODE="${1}"
         "${1}"
-        RC="$?"
+        exit "$?"
         ;;
     *)
         echo "Usage: $0 {start|stop|refresh}"
-        RC="${SMF_EXIT_ERR_NOSMF}"
+        exit "${SMF_EXIT_ERR_NOSMF}"
         ;;
 esac
-
-exit "${RC}"

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -1,0 +1,447 @@
+#!/usr/bin/ksh93
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T. All rights reserved.
+# Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2017 Joyent, Inc.
+# Copyright 2017 Erigones, s. r. o.
+#
+
+. /lib/svc/share/smf_include.sh
+. /lib/sdc/config.sh
+. /lib/sdc/network.sh
+
+set -o errexit
+set -o xtrace
+
+# Makes sense only in the global zone
+smf_is_globalzone || exit "${SMF_EXIT_OK}"
+
+# Make sure that the libraries essential to this stage of booting can be found.
+LD_LIBRARY_PATH=/lib; export LD_LIBRARY_PATH
+
+# Hard-coded in nictagadm and in other places
+OVERLAY_RULES="/var/run/smartdc/networking/overlay_rules.json"
+
+typeset -a Etherstubs
+
+
+function log_if_state
+{
+    echo "== debug start: $1 =="
+    if ! /sbin/ifconfig -a; then
+        echo "WARNING: 'ifconfig -a' failed"
+    fi
+    echo "== debug end: $1 =="
+}
+
+function valid_mtu
+{
+    set -o xtrace
+    typeset tag="$1"
+    typeset mtu="$2"
+
+    if ! [[ "${mtu}" =~ [1-9][0-9][0-9][0-9] ]] ; then
+        echo "Invalid mtu specified for tag ${tag}: ${mtu}"
+        echo "Valid MTU range is from 1500-9000"
+        exit "${SMF_EXIT_ERR_FATAL}"
+    fi
+
+    if [[ "${mtu}" -gt 9000 || "${mtu}" -lt 1500 ]]; then
+        echo "Invalid mtu specified for tag ${tag}: ${mtu}"
+        echo "Valid MTU range is from 1500-9000"
+        exit "${SMF_EXIT_ERR_FATAL}"
+    fi
+}
+
+# Creates, plumbs and brings up a vnic with the specified inet parameters
+function vnic_up
+{
+    set -o xtrace
+
+    typeset link="$1"
+    typeset iface="$2"
+    typeset ip="$3"
+    typeset netmask="$4"
+    typeset vlan_id="$5"
+    typeset mac_addr="$6"
+    typeset dhcp_primary="$7"
+    typeset mtu="$8"
+    typeset details=
+    typeset vlan_opt=
+    typeset mac_addr_opt=
+    typeset prop_opt=
+
+    details="link='${link}', iface='${iface}', ip='${ip}', netmask='${netmask}, vlan_id='${vlan_id}'"
+
+    if [[ -z "${link}" ]] || [[ -z "${iface}" ]] || \
+       [[ -z "${ip}" ]] || ([[ ${ip} != "dhcp" ]] && [[ -z "${netmask}" ]]); then
+        echo "WARNING: not bringing up nic (insufficient configuration): ${details}"
+        return
+    fi
+
+    eval "vnic_already_up=\${vnic_${iface}_up}"
+
+    if [[ -n "${vnic_already_up}" ]]; then
+        echo "WARNING: VNIC already up: ${details}"
+        return
+    fi
+
+    echo "Bringing up VNIC: ${details}"
+
+    if [[ -n "${vlan_id}" ]] && [[ "${vlan_id}" -ne 0 ]]; then
+        vlan_opt="-v ${vlan_id}"
+    fi
+
+    if [[ -n "${mac_addr}" ]]; then
+        mac_addr_opt="-m ${mac_addr}"
+    fi
+
+    if [[ -n "${mtu}" ]]; then
+        valid_mtu "${iface}" "${mtu}"
+        prop_opt="-p mtu=${mtu}"
+    fi
+
+    if ! /usr/sbin/dladm create-vnic -t -l "${link}" ${prop_opt} ${vlan_opt} ${mac_addr_opt} "${iface}"; then
+        echo "Failed to create VNIC: ${iface}"
+        exit "${SMF_EXIT_ERR_FATAL}"
+    fi
+
+    if ! /sbin/ifconfig "${iface}" plumb; then
+        echo "Failed to plumb VNIC: ${iface}"
+        exit "${SMF_EXIT_ERR_FATAL}"
+    fi
+
+    if [[ "${ip}" == "dhcp" ]]; then
+        # We ignore errors here because the most common one is that DHCP is already running.
+        if [[ -n "${dhcp_primary}" ]]; then
+            /sbin/ifconfig "${iface}" dhcp primary || /bin/true
+        else
+            /sbin/ifconfig "${iface}" dhcp || /bin/true
+        fi
+    else
+        /sbin/ifconfig "${iface}" inet "${ip}" netmask "${netmask}" up
+    fi
+
+    eval "vnic_${iface}_up=true"
+}
+
+# Creates, plumbs and brings up a vnic with the specified inet6 parameters
+function vnic_up6
+{
+    set -o xtrace
+
+    typeset link="$1"
+    typeset iface="$2"
+    typeset ip="$3"
+    typeset vlan_id="$4"
+    typeset mac_addr="$5"
+    typeset mtu="$6"
+    typeset details=
+    typeset vlan_opt=
+    typeset mac_addr_opt=
+    typeset prop_opt=
+
+    details="link='${link}', iface='${iface}', ip6='${ip}', vlan_id='${vlan_id}'"
+
+    if [[ -z "${link}" ]] || [[ -z "${iface}" ]] || [[ -z "${ip}" ]]; then
+        echo "WARNING: not bringing up nic (insufficient configuration): ${details}"
+        return
+    fi
+
+    # only bring up nic if not already up
+    eval "vnic_already_up=\${vnic_${iface}_up}"
+
+    if [[ -z "${vnic_already_up}" ]]; then
+        echo "Bringing up VNIC: ${details}"
+
+        if [[ -n "${vlan_id}" ]] && [[ "${vlan_id}" -ne 0 ]]; then
+            vlan_opt="-v ${vlan_id}"
+        fi
+
+        if [[ -n "${mac_addr}" ]]; then
+            mac_addr_opt="-m ${mac_addr}"
+        fi
+
+        if [[ -n "${mtu}" ]]; then
+            valid_mtu "${iface}" "${mtu}"
+            prop_opt="-p mtu=${mtu}"
+        fi
+
+        if ! /usr/sbin/dladm create-vnic -t -l "${link}" ${prop_opt} ${vlan_opt} ${mac_addr_opt} "${iface}"; then
+            echo "Failed to create VNIC: ${iface}"
+            exit "${SMF_EXIT_ERR_FATAL}"
+        fi
+    fi
+
+    if ! /sbin/ifconfig "${iface}" inet6 plumb; then
+        echo "Failed to plumb VNIC: ${iface}"
+        exit "${SMF_EXIT_ERR_FATAL}"
+    fi
+
+    if [[ -n "${ip}" ]]; then
+        /sbin/ifconfig "${iface}" inet6 up
+    fi
+
+    if [[ "${ip}" != "addrconf" ]]; then
+        /sbin/ifconfig "${iface}" inet6 addif "${ip}" preferred up
+    fi
+
+    eval "vnic_${iface}_up=true"
+}
+
+function is_etherstub
+{
+    typeset value="$1"
+
+    for stub in "${Etherstubs[@]}"; do
+        if [[ "${stub}" == "${value}" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Retrieve all necessary information about a vnic,
+# make sure its link exists,
+# call vnic_up.
+function setup_vnic
+{
+    set -o xtrace
+    typeset tag="$1"
+    typeset iface="$2"
+    typeset vnic_name="${iface}"
+    typeset config_source="${3:-"CONFIG"}"
+    typeset ip_version="${4:-"4"}"
+    typeset link=
+
+    echo "Configuring VNIC: ${iface} (tag: ${tag})"
+
+    # Find link name for a vnic
+    eval "vxlan_id=\${${config_source}_${iface}_vxlan_id}"
+
+    if [[ -n "${vxlan_id}" ]]; then
+        # We have a vnic on overlay
+        overlay_rule_name="${tag}"
+        link="${overlay_rule_name}${vxlan_id}"
+
+        if [[ ! "${vxlan_id}" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Invalid overlay VXLAN for VNIC: ${iface}"
+            return 1
+        fi
+
+        # Create the overlay if necessary
+        if dladm show-overlay "${link}" > /dev/null 2>&1; then
+            echo "NOTE: Overlay \"${link}\" already exists for VNIC: ${iface}"
+        else
+            eval "overlay_rule=\${SYSINFO_OverlayRule_${overlay_rule_name}}"
+
+            if [[ -z "${overlay_rule}" ]]; then
+                echo "ERROR: Missing overlay rule \"${overlay_rule_name}\" for VNIC: ${iface}"
+                return 1
+            fi
+
+            echo "NOTE: Creating overlay \"${link}\" for VNIC: ${iface}"
+
+            if ! dladm create-overlay ${overlay_rule} -v "${vxlan_id}" -t "${link}"; then
+                echo "ERROR: Could not create overlay \"${link}\" for VNIC: ${iface}"
+                return 1
+            fi
+        fi
+    elif is_etherstub "${tag}"; then
+        # We have a vnic on etherstub
+        link="${tag}"
+
+        if [[ "${iface}" == "${link}"* ]]; then
+            # Normalize interface name (bar010 -> bar10, foo03 -> foo3)
+            vnic_prefix="$(echo "${link}" | sed 's/\([a-zA-Z_\.-]\)0$/\1/')"
+            vnic_name="${vnic_prefix}${iface:${#link}}"
+        fi
+    else
+        # We have a vnic on normal/aggr interface
+        eval "link=\${SYSINFO_NIC_${tag}}"
+
+        if [[ -z "${link}" ]]; then
+            echo "WARNING: No link found for VNIC: ${iface}"
+            return 0
+        fi
+    fi
+
+    # Get vnic_ip parameters
+    eval "vlan=\${${config_source}_${iface}_vlan_id}"
+    eval "macaddr=\${${config_source}_${iface}_mac}"
+    eval "mtu=\${${config_source}_${iface}_mtu}"
+
+    # Call vnic_up
+    if [[ ${ip_version} == "6" ]]; then
+        eval "ip=\${${config_source}_${iface}_ip6}"
+        netmask=""
+
+        echo vnic_up6 "${link}" "${vnic_name}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
+        vnic_up6 "${link}" "${vnic_name}" "${ip}" "${vlan}" "${macaddr}" "${mtu}"
+    else
+        eval "ip=\${${config_source}_${iface}_ip}"
+        eval "netmask=\${${config_source}_${iface}_netmask}"
+
+        echo vnic_up "${link}" "${vnic_name}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "" "${mtu}"
+        vnic_up "${link}" "${vnic_name}" "${ip}" "${netmask}" "${vlan}" "${macaddr}" "" "${mtu}"
+    fi
+}
+
+
+#
+# Create overlay_rules.json
+#
+function create_overlay_rules
+{
+    set -o xtrace
+
+    # Create overlay_rules.json
+    config_overlay_rules="$(sdc_config_keys | grep "^overlay_rule_[a-zA-Z0-9_]*[a-zA-Z_]$" | cut -d "_" -f 3-)"
+
+    if [[ -n "${config_overlay_rules}" ]]; then
+        # The overlay configuration folder is placed on swap (does not exist after boot)
+        mkdir -p "$(dirname "${OVERLAY_RULES}")"
+        overlay_rules="{"
+
+        for overlay_name in ${config_overlay_rules}; do
+            eval "overlay_rule=\${CONFIG_overlay_rule_${overlay_name}}"
+            overlay_rules="${overlay_rules}\n    \"${overlay_name}\": \"${overlay_rule}\","
+        done
+
+        echo "$(echo "${overlay_rules}" | sed '$s/,$//')\n}" > "${OVERLAY_RULES}"
+
+        # Reload sysinfo (overlay rules are part of SYSINFO_Nic_Tags)
+        /usr/bin/sysinfo -u
+        load_sdc_sysinfo
+    fi
+}
+
+#
+# Setup vnics
+#
+function create_vnics
+{
+    set -o xtrace
+
+    nic_tags="${SYSINFO_Nic_Tags}"
+
+    if [[ -z "${nic_tags}" ]]; then
+        return
+    fi
+
+    # VNICs must be created in order depending on their link type
+    # (= VNICs on overlays must go last)
+    typeset -a tags=(${nic_tags//,/ })
+    typeset -a tags_first
+    typeset -a tags_last
+
+    for _tag in "${tags[@]}"; do
+        eval "is_overlay_rule=\${SYSINFO_OverlayRule_${_tag}}"
+
+        if [[ -z "${is_overlay_rule}" ]]; then
+            tags_first+=("${_tag}")
+        else
+            tags_last+=("${_tag}")
+        fi
+    done
+
+    if boot_file_config_enabled; then
+        bootparam_ip_keys=""
+        bootparam_ip6_keys=""
+        config_ip_keys=${CONFIG_bootfile_ip_keys//,/ }
+        config_ip6_keys=${CONFIG_bootfile_ip6_keys//,/ }
+    else
+        bootparam_ip_keys=$(sdc_bootparams_keys | grep -- "-ip$" || true)
+        bootparam_ip6_keys=$(sdc_bootparams_keys | grep -- "-ip6$" || true)
+        config_ip_keys=$(sdc_config_keys | grep "_ip$" || true)
+        config_ip6_keys=$(sdc_config_keys | grep "_ip6$" || true)
+    fi
+
+    for tag in "${tags_first[@]}" "${tags_last[@]}"; do
+        for key in ${config_ip_keys}; do
+            if [[ ${key} == ${tag}[0-9]_ip ]] || [[ ${key} == ${tag}[0-9][0-9]_ip ]]; then
+                iface=${key//_ip/}
+                setup_vnic "${tag}" "${iface}" "CONFIG" "4"
+            fi
+        done
+
+        for key in ${bootparam_ip_keys}; do
+            if [[ ${key} == ${tag}[0-9]-ip ]] || [[ ${key} == ${tag}[0-9][0-9]-ip ]]; then
+                iface=${key//-ip/}
+                setup_vnic "${tag}" "${iface}" "BOOT" "4"
+                fi
+        done
+
+        for key in ${config_ip6_keys}; do
+            if [[ ${key} == ${tag}[0-9]_ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]_ip6 ]]; then
+                iface=${key//_ip6/}
+                setup_vnic "${tag}" "${iface}" "CONFIG" "6"
+            fi
+        done
+
+        for key in ${bootparam_ip6_keys}; do
+            if [[ ${key} == ${tag}[0-9]-ip6 ]] || [[ ${key} == ${tag}[0-9][0-9]-ip6 ]]; then
+                iface=${key//-ip6/}
+                setup_vnic "${tag}" "${iface}" "BOOT" "6"
+            fi
+        done
+
+    done
+}
+
+
+# Load sysinfo variables with SYSINFO_ prefix
+load_sdc_sysinfo
+
+if boot_file_config_enabled; then
+    # We have a boot-time networking file present - use its values rather
+    # than ones from the config file or bootparams
+    if ! boot_file_config_valid; then
+        echo "ERROR: boot-time network config file incorrect"
+        exit "${SMF_EXIT_ERR_CONFIG}"
+    fi
+
+    load_boot_file_config
+    boot_file_config_init
+else
+    # Load config variables with CONFIG_ prefix,
+    # and sets the headnode variable
+    load_sdc_config
+    # Load boot params with BOOT_ prefix
+    load_sdc_bootparams
+fi
+
+if [[ -n "${CONFIG_etherstub}" ]]; then
+    Etherstubs=(${CONFIG_etherstub//,/ })
+else
+    Etherstubs=()
+fi
+
+log_if_state before
+create_overlay_rules
+create_vnics
+log_if_state after
+/usr/bin/sysinfo -u
+
+exit "${SMF_EXIT_OK}"

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -98,8 +98,8 @@
 # + VNICs on normal and aggregation interfaces require <nic_tag>_nic=
 # + VNICs on overlays require <nic_tag>_<integer:vnic-suffix>_vxlan_id=
 #
-# NOTE: The <nic_tag>_<integer:vnic-suffix> format is preferred.
-#       (note the underscore)
+# NOTE: The <nic_tag>_<integer:vnic-suffix> format is preferred for VNICs over
+#       etherstub and overlay links (note the underscore).
 #
 #######################################
 

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -28,10 +28,17 @@
 
 #
 # This script is responsible for creating VNICs (dladm create-vnic) based on
-# configuration in /usbkey/config or provided via boot parameters. It can also
-# create (replace) the overlay_rules.json file. Overlays are created only
-# if a VNIC is configured to be over an overlay. Etherstubs are created in
-# network/physical.
+# configuration in /usbkey/config or provided via boot parameters. It will
+# create all VNICs defined by `<nic_tag>_<vnic-suffix_integer>_ip` entries in
+# the config file or `<nic_tag>_<vnic-suffix_integer>-ip` boot parameters.
+# VNICs defined by `admin_ip` and `external_ip` statements are still managed
+# by network/physical.
+#
+# Etherstubs are also created in network/physical.
+#
+# This script can create (replace) the overlay_rules.json file. Overlays are
+# created only if an underlying link of a VNIC is an overlay (detected by
+# `<nic_tag>_<vnic-suffix_integer>_vxlan_id`).
 #
 # It also supports creating of new VNICs added to /usbkey/config on a running
 # system via the `refresh` parameter. However, the refresh functionality is
@@ -91,14 +98,14 @@
 #######################################
 # The /usbkey/config entries are based on the following pattern:
 #
-# <nic_tag>_<integer:vnic-suffix>_ip=
-# <nic_tag>_<integer:vnic-suffix>_netmask=
+# <nic_tag>_<vnic-suffix_integer>_ip=
+# <nic_tag>_<vnic-suffix_integer>_netmask=
 # ... and so on ...
 #
 # + VNICs on normal and aggregation interfaces require <nic_tag>_nic=
-# + VNICs on overlays require <nic_tag>_<integer:vnic-suffix>_vxlan_id=
+# + VNICs on overlays require <nic_tag>_<vnic-suffix_integer>_vxlan_id=
 #
-# NOTE: The <nic_tag>_<integer:vnic-suffix> format is preferred for VNICs over
+# NOTE: The <nic_tag>_<vnic-suffix_integer> format is preferred for VNICs over
 #       etherstub and overlay links (note the underscore).
 #
 #######################################
@@ -504,7 +511,7 @@ function stop
 {
     set -o errexit
 
-    echo "ERROR: Not implemented" >&2
+    echo "WARNING: Not implemented" >&2
 
     return "${SMF_EXIT_OK}"
 }
@@ -553,7 +560,7 @@ fi
 case "${1}" in
     start|stop|refresh)
         MODE="${1}"
-        "${1}"
+        "${MODE}"
         exit "$?"
         ;;
     *)

--- a/lib/svc/method/net-virtual
+++ b/lib/svc/method/net-virtual
@@ -43,6 +43,7 @@ LD_LIBRARY_PATH=/lib; export LD_LIBRARY_PATH
 OVERLAY_RULES="/var/run/smartdc/networking/overlay_rules.json"
 
 typeset -a Etherstubs
+typeset MODE
 
 
 function log_if_state
@@ -52,6 +53,15 @@ function log_if_state
         echo "WARNING: 'ifconfig -a' failed"
     fi
     echo "== debug end: $1 =="
+}
+
+function load_etherstubs
+{
+    if [[ -n "${CONFIG_etherstub}" ]]; then
+        Etherstubs=(${CONFIG_etherstub//,/ })
+    else
+        Etherstubs=()
+    fi
 }
 
 function valid_mtu
@@ -122,12 +132,12 @@ function vnic_up
     fi
 
     if ! /usr/sbin/dladm create-vnic -t -l "${link}" ${prop_opt} ${vlan_opt} ${mac_addr_opt} "${iface}"; then
-        echo "Failed to create VNIC: ${iface}"
+        echo "ERROR: Failed to create VNIC: ${iface}"
         exit "${SMF_EXIT_ERR_FATAL}"
     fi
 
     if ! /sbin/ifconfig "${iface}" plumb; then
-        echo "Failed to plumb VNIC: ${iface}"
+        echo "ERROR: Failed to plumb VNIC: ${iface}"
         exit "${SMF_EXIT_ERR_FATAL}"
     fi
 
@@ -188,13 +198,13 @@ function vnic_up6
         fi
 
         if ! /usr/sbin/dladm create-vnic -t -l "${link}" ${prop_opt} ${vlan_opt} ${mac_addr_opt} "${iface}"; then
-            echo "Failed to create VNIC: ${iface}"
+            echo "ERROR: Failed to create VNIC: ${iface}"
             exit "${SMF_EXIT_ERR_FATAL}"
         fi
     fi
 
     if ! /sbin/ifconfig "${iface}" inet6 plumb; then
-        echo "Failed to plumb VNIC: ${iface}"
+        echo "ERROR: Failed to plumb VNIC: ${iface}"
         exit "${SMF_EXIT_ERR_FATAL}"
     fi
 
@@ -228,6 +238,7 @@ function is_etherstub
 function setup_vnic
 {
     set -o xtrace
+
     typeset tag="$1"
     typeset iface="$2"
     typeset vnic_name="${iface}"
@@ -250,10 +261,8 @@ function setup_vnic
             return 1
         fi
 
-        # Create the overlay if necessary
-        if dladm show-overlay "${link}" > /dev/null 2>&1; then
-            echo "NOTE: Overlay \"${link}\" already exists for VNIC: ${iface}"
-        else
+        # Create the overlay if necessary (the return code of dladm show-overlay may be misleading)
+        if dladm show-overlay "${link}" 2>&1 | grep "object not found" > /dev/null; then
             eval "overlay_rule=\${SYSINFO_OverlayRule_${overlay_rule_name}}"
 
             if [[ -z "${overlay_rule}" ]]; then
@@ -267,6 +276,8 @@ function setup_vnic
                 echo "ERROR: Could not create overlay \"${link}\" for VNIC: ${iface}"
                 return 1
             fi
+        else
+            echo "NOTE: Overlay \"${link}\" already exists for VNIC: ${iface}"
         fi
     elif is_etherstub "${tag}"; then
         # We have a vnic on etherstub
@@ -285,6 +296,11 @@ function setup_vnic
             echo "WARNING: No link found for VNIC: ${iface}"
             return 0
         fi
+    fi
+
+    if [[ "${MODE}" == "refresh" ]] && dladm show-vnic "${vnic_name}" > /dev/null 2>&1; then
+        echo "WARNING: VNIC \"${vnic_name}\" already exists"
+        return 0
     fi
 
     # Get vnic_ip parameters
@@ -343,6 +359,7 @@ function create_overlay_rules
 function create_vnics
 {
     set -o xtrace
+    # set -o errexit
 
     nic_tags="${SYSINFO_Nic_Tags}"
 
@@ -406,10 +423,40 @@ function create_vnics
                 setup_vnic "${tag}" "${iface}" "BOOT" "6"
             fi
         done
-
     done
 }
 
+function start
+{
+    log_if_state before
+    create_overlay_rules
+    create_vnics
+    log_if_state after
+    /usr/bin/sysinfo -u
+
+    return "${SMF_EXIT_OK}"
+}
+
+function stop
+{
+    echo "ERROR: Not implemented" >&2
+
+    return "${SMF_EXIT_OK}"
+}
+
+function refresh
+{
+    echo "NOTE: Changing or removing existing VNICs is currently not supported." >&2
+    echo "NOTE: Only adding of new VNICs will work." >&2
+
+    start
+
+    return "$?"
+}
+
+####
+# Initialize variables
+####
 
 # Load sysinfo variables with SYSINFO_ prefix
 load_sdc_sysinfo
@@ -432,16 +479,22 @@ else
     load_sdc_bootparams
 fi
 
-if [[ -n "${CONFIG_etherstub}" ]]; then
-    Etherstubs=(${CONFIG_etherstub//,/ })
-else
-    Etherstubs=()
-fi
+load_etherstubs
 
-log_if_state before
-create_overlay_rules
-create_vnics
-log_if_state after
-/usr/bin/sysinfo -u
+####
+# Run
+####
 
-exit "${SMF_EXIT_OK}"
+case "${1}" in
+    start|stop|refresh)
+        MODE="${1}"
+        "${1}"
+        RC="$?"
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|refresh}"
+        RC="${SMF_EXIT_ERR_NOSMF}"
+        ;;
+esac
+
+exit "${RC}"

--- a/manifest
+++ b/manifest
@@ -4,6 +4,7 @@ f root/.vimrc 0644 root root
 f root/.bash_profile 0644 root root
 f root/.bashrc 0644 root root
 f lib/svc/manifest/network/network-cleanup.xml 0444 root sys
+f lib/svc/manifest/network/network-virtual.xml 0444 root sys
 f lib/svc/manifest/rc-post-vmadmd.xml 0444 root sys
 f lib/svc/manifest/rc-pre-network.xml 0444 root sys
 f lib/svc/manifest/rc-pre-vmadmd.xml 0444 root sys
@@ -11,6 +12,7 @@ f lib/svc/method/fs-joyent 0555 root bin
 f lib/svc/method/fs-root 0555 root bin
 f lib/svc/method/net-cleanup 0555 root sys
 f lib/svc/method/net-physical 0555 root sys
+f lib/svc/method/net-virtual 0555 root sys
 f lib/svc/method/postboot-rc-init 0555 root sys
 f lib/svc/method/smartdc-config 0555 root bin
 f lib/svc/method/smartdc-init 0555 root bin

--- a/usr/bin/sysinfo
+++ b/usr/bin/sysinfo
@@ -28,6 +28,7 @@ FORCE=
 PARSABLE=
 UPDATE_ONLY=
 ZSTAT=
+OVERLAY_RULES="/var/run/smartdc/networking/overlay_rules.json"
 
 while getopts fnpu? name
 do
@@ -499,6 +500,39 @@ function get_smartos_network_interfaces()
     #done
 }
 
+function get_smartos_overlay_rules()
+{
+    count=1
+
+    if [[ -f "${OVERLAY_RULES}" ]]; then
+        nic_tag_count=0
+
+        while [[ ${nic_tag_count} -lt ${NicTagCount} ]]; do
+            tag_name=${NicTagNames[${nic_tag_count}]}
+            ((nic_tag_count++))
+
+            overlay_rule=$(json -f "${OVERLAY_RULES}" "${tag_name}")
+
+            if [[ $? -eq 0 && -n "${overlay_rule}" ]]; then
+                OverlayRules[${count}]="${tag_name}"
+                eval "OverlayRule_${tag_name}='${overlay_rule}'"
+                ((count++))
+            fi
+        done
+    fi
+}
+
+function get_smartos_overlays() {
+    count=1
+
+    for line in $(/sbin/dladm show-overlay -f -p -o link,status); do
+        fields=(${line//:/ })
+        Overlays[${count}]="${fields[0]}"
+        eval "Overlay_${fields[0]}='${fields[1]}'"
+        ((count++))
+    done
+}
+
 function get_smartos_vnics()
 {
     count=1
@@ -569,17 +603,18 @@ function get_nic_tags()
 {
     NicTagCount=0
     NicTagList=
-    for line in $(nictagadm list -d '=' -p -L 2>/dev/null); do
+
+    while read line; do
         fields=(${line//=/ })
 
         NicTagNames[${NicTagCount}]=${fields[0]}
         NicTagMacs[${NicTagCount}]=${fields[1]}
         NicTagLinks[${NicTagCount}]=${fields[2]}
 
-        [[ -n $NicTagList ]] && NicTagList=${NicTagList},
+        [[ -n $NicTagList ]] && NicTagList="${NicTagList},"
         NicTagList=${NicTagList}${fields[0]}
         ((NicTagCount++))
-    done
+    done <<< "$(nictagadm list -d '=' -p 2>/dev/null)"
 }
 
 function get_aggr_params()
@@ -788,6 +823,18 @@ END
         nicnames_var="Etherstub_${stub}_NIC_Names"
         eval "nicnames=\${${nicnames_var}}"
         echo "${nicnames_var}='${nicnames}'"
+    done
+
+    for overlay_rule_name in "${OverlayRules[@]}"; do
+        overlay_rule_var="OverlayRule_${overlay_rule_name}"
+        eval "overlay_rule=\${${overlay_rule_var}}"
+        echo "${overlay_rule_var}='${overlay_rule}'"
+    done
+
+    for overlay_name in "${Overlays[@]}"; do
+        overlay_var="Overlay_${overlay_name}"
+        eval "overlay_status=\${${overlay_var}}"
+        echo "${overlay_var}='${overlay_status}'"
     done
 
     for entry in "${Bootparams[@]}"; do
@@ -1042,6 +1089,40 @@ END
     done
 
     cat <<END
+  },
+  "Overlays": {
+END
+    printed=0
+    for overlay in "${Overlays[@]}"; do
+        overlay_var="Overlay_${overlay_name}"
+        eval "overlay_status=\${${overlay_var}}"
+
+        ((printed++))
+        trailing_comma=","
+        [[ ${printed} -eq ${#Overlays[*]} ]] && trailing_comma=""
+
+        echo -n "    \"${overlay}\": \"${overlay_status}\""
+        echo "${trailing_comma}"
+    done
+
+    cat <<END
+  },
+  "Overlay Rules": {
+END
+    printed=0
+    for overlay_rule_name in "${OverlayRules[@]}"; do
+        overlay_rule_var="OverlayRule_${overlay_rule_name}"
+        eval "overlay_rule=\${${overlay_rule_var}}"
+
+        ((printed++))
+        trailing_comma=","
+        [[ ${printed} -eq ${#OverlayRules[*]} ]] && trailing_comma=""
+
+        echo -n "    \"${overlay_rule_name}\": \"${overlay_rule}\""
+        echo "${trailing_comma}"
+    done
+
+    cat <<END
   }
 }
 END
@@ -1071,6 +1152,8 @@ get_aggregation_mappings
 get_overlay_nic_tags
 get_nic_tags
 get_smartos_network_interfaces
+get_smartos_overlay_rules
+get_smartos_overlays
 get_smartos_vnics
 get_smartos_etherstubs
 get_aggr_params

--- a/usr/bin/sysinfo
+++ b/usr/bin/sysinfo
@@ -1016,7 +1016,7 @@ END
         ipv4_var="Virtual_Network_Interface_${iface}_IPv4_Address"
         link_status_var="Virtual_Network_Interface_${iface}_Link_Status"
         vlan_var="Virtual_Network_Interface_${iface}_VLAN"
-        parent_var="Virtual_Network_Interface_${iface}_Host_Interface"
+        host_var="Virtual_Network_Interface_${iface}_Host_Interface"
 
         eval "mac=\${${mac_var}}"
         eval "ipv4=\${${ipv4_var}}"


### PR DESCRIPTION
Moved VNIC creation from `network/physical` to new SMF service: `network/virtual`. This change is related to network overlays - erigones/esdc-ce#286.

The `net-virtual` script is responsible for creating VNICs (dladm create-vnic) based on configuration in /usbkey/config or provided via boot parameters. It can also create (replace) the overlay_rules.json file. Overlays are created only if a VNIC is configured to be over an overlay. Etherstubs are created in
network/physical.

I t also supports creating of new VNICs added to /usbkey/config on a running system via the `refresh` parameter. However, the refresh functionality is currently limited to configuration of VNICs that do not exist in the OS yet.